### PR TITLE
Seed random generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These are simple tools to manipulate sequence data.
 
 ## Build instructions
   1. clone this repository: `git clone --recurse-submodules https://github.com/SGSSGene/seqan3_tools`
-  2. create and enter build folder: `mkdir seqan3_search/build; cd seqan3_search/build`
+  2. create and enter build folder: `mkdir seqan3_tools/build; cd seqan3_tools/build`
   3. run cmake with release options: `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-mpopcnt -march=native" ..`
   4. compile with `make`
   5. (optional) put them in your PATH variable `PATH="${PATH}:path/to/seqan3_tools/build/bin"`

--- a/src/st_dna5todna4.cpp
+++ b/src/st_dna5todna4.cpp
@@ -1,3 +1,4 @@
+#include <ctime>
 #include <filesystem>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/argument_parser/all.hpp>
@@ -26,6 +27,7 @@ int main(int argc, char const* const* argv) {
     seqan3::sequence_file_input fin{infile};
     seqan3::sequence_file_output fout{std::cout, seqan3::format_fasta{}};
 
+    std::srand(std::time(0));
     // iterate through all sequences in input file
     for (auto & record : fin) {
         std::vector<seqan3::dna5> sequence;


### PR DESCRIPTION
By default `rand()` is seeded with 1. The DNA5 to DNA4 converter will always turn long stretches of N's into the same DNA4 sequences which causes pseudo alignments